### PR TITLE
Made version check compatible with Ruby 1.9.

### DIFF
--- a/lib/gov_kit.rb
+++ b/lib/gov_kit.rb
@@ -10,7 +10,7 @@ require 'json'
 require 'gov_kit/configuration'
 require 'csv'
 
-if VERSION[0,3] == "1.8"
+if RUBY_VERSION[0,3] == "1.8"
   require 'fastercsv'
 end
 


### PR DESCRIPTION
The code that loads fastercsv if we're on Ruby 1.8 was failing on 1.9.
