### PR TITLE
Added URI.encode to openstates call.

### DIFF
--- a/lib/gov_kit/open_states.rb
+++ b/lib/gov_kit/open_states.rb
@@ -19,7 +19,8 @@ module GovKit
     # we return an empty set.
     def self.get_uri(uri, options={})
       begin
-        response = get(uri, options)
+	
+        response = get(URI.encode(uri), options)
         result = parse(response)
       rescue ResourceNotFound
         return []


### PR DESCRIPTION
Hello,
I added a URI.encode to openstates get uri call.
Since if the bill id has a space it will break. It should be encoded so the spaces and other special characters can be escaped before being used.
