### PR TITLE
Fixes to get follow_the_money_spec passing

### DIFF
--- a/lib/gov_kit/follow_the_money.rb
+++ b/lib/gov_kit/follow_the_money.rb
@@ -8,6 +8,7 @@ module GovKit
   class FollowTheMoneyResource < Resource
     default_params :key => GovKit::configuration.ftm_apikey
     base_uri GovKit::configuration.ftm_base_url
+    format :xml
 
     # Common method used by subclasses to get data from the service.
     #
@@ -19,7 +20,7 @@ module GovKit
     #   doc = get_xml("/base_level.industries.list.php", :query => {:page => page_num})
     #
     def self.get_xml(path, options)
-      doc = Nokogiri::XML(get(path, options))
+      doc = Nokogiri::XML(get(path, options).body)
 
       e = doc.search("//error")
 


### PR DESCRIPTION
FollowTheMoneyResource expects the format to be xml when performing an HTTP get on the api.
- Changed the FollowTheMoneyResource format to xml.
- Call the body method of the HTTParty response to retrieve the XML.

The follow_the_money spec now passes.
