### PR TITLE
Break implicit spec dependency

### DIFF
--- a/spec/follow_the_money_spec.rb
+++ b/spec/follow_the_money_spec.rb
@@ -4,6 +4,10 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 # which is used by resource_for_collection, in resource.rb
 require 'active_support/inflector'
 
+# Provides the blank? method
+# which is used by parse in resource.rb
+require 'active_support/core_ext/object'
+
 module GovKit::FollowTheMoney
   describe GovKit::FollowTheMoney do
 


### PR DESCRIPTION
follow_the_money_spec.rb implicitly depended on other spec
files to require active_support/core_ext/object, which
defines the blank? method and is used by resource.rb.

Now 'rspec spec/follow_the_money_spec.rb' passes standalone.
