### PR TITLE
Remove the hardcoded Resource format

### DIFF
--- a/lib/gov_kit/open_states.rb
+++ b/lib/gov_kit/open_states.rb
@@ -49,6 +49,8 @@ module GovKit
     # http://openstates.sunlightlabs.com/api/metadata/, 
     #
     class State < OpenStatesResource
+      format :json
+
       def self.find_by_abbreviation(abbreviation)
         get_uri("/metadata/#{abbreviation}/")
       end

--- a/lib/gov_kit/resource.rb
+++ b/lib/gov_kit/resource.rb
@@ -19,7 +19,6 @@ module GovKit
   # Includes {http://rdoc.info/github/jnunemaker/httparty/master/HTTParty/ClassMethods HTTParty}, which provides convenience methods like get().
   class Resource
     include HTTParty
-    format :json
 
     # The attributes data returned by the service.
     attr_reader :attributes

--- a/spec/transparency_data_spec.rb
+++ b/spec/transparency_data_spec.rb
@@ -18,9 +18,9 @@ module GovKit::TransparencyData
         ['/contributions.json\?',                         'contributions.response'],
         ['/lobbying.json\?',                              'lobbyists_find_all.response'],
         ['/grants.json\?',                                'grants_find_all.response'],
-        ['/entities.json\?apikey=&search=$',              'entities_search.response'],
-        ['/entities.json\?apikey=&search=harry%20pelosi', 'entities_search_limit_0.response'],
-        ['/entities.json\?apikey=&search=nancy%2Bpelosi', 'entities_search_limit_1.response']
+        ['/entities.json\?apikey=YOUR_OPENSTATES_API_KEY&search=$',              'entities_search.response'],
+        ['/entities.json\?apikey=YOUR_OPENSTATES_API_KEY&search=harry%20pelosi', 'entities_search_limit_0.response'],
+        ['/entities.json\?apikey=YOUR_OPENSTATES_API_KEY&search=nancy%2Bpelosi', 'entities_search_limit_1.response']
       ]
 
       urls.each do |u|


### PR DESCRIPTION
This allows HTTParty to detect the format type
by looking at the Content-Type in the response
and use the appropriate parser.

Needed to explicitly add the json format to State,
since the fixture has a blank Content-Type.

Now rspec spec/open_states_spec.rb passes.

This fixes the tests for HTTP error codes.
They are plain text, which HTTParty does not
check for before handing off to the JSON parser.
