### PR TITLE
Fix Rakefile to use the new rspec API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,22 +60,19 @@ Rake::RDocTask.new do |rdoc|
 end
 
 
-if defined?(Spec)
+if defined?(RSpec)
   desc 'Test the govkit plugin.'
-  Spec::Rake::SpecTask.new('spec') do |t|
-    t.spec_files = FileList['spec/**/*_spec.rb']
-    t.spec_opts = ["-c"]
+  RSpec::Core::RakeTask.new('spec') do |t|
+    t.rspec_opts = ["-c"]
   end
 
   desc 'Test the govkit plugin with specdoc formatting and colors'
-  Spec::Rake::SpecTask.new('specdoc') do |t|
-    t.spec_files = FileList['spec/**/*_spec.rb']
-    t.spec_opts = ["--format specdoc", "-c"]
+  RSpec::Core::RakeTask.new('specdoc') do |t|
+    t.rspec_opts = ["--format specdoc", "-c"]
   end
 
   desc "Run all examples with RCov"
-  Spec::Rake::SpecTask.new('examples_with_rcov') do |t|
-    t.spec_files = FileList['spec/**/*_spec.rb']
+  RSpec::Core::RakeTask.new('examples_with_rcov') do |t|
     t.rcov = true
     t.rcov_opts = ['--exclude', 'spec,Library']
   end


### PR DESCRIPTION
Running `rake` will now kick off rspec by default.
The FileList pattern is not needed, this pattern is the default.
