### PR TITLE
Add top_industry_contributors method to TransparencyData Aggregate class

### DIFF
--- a/lib/gov_kit/transparency_data.rb
+++ b/lib/gov_kit/transparency_data.rb
@@ -133,6 +133,13 @@ module GovKit
         response = get("/aggregates/pol/#{id}/contributors/type_breakdown.json", :query => ops)
         parse(response)
       end
+      
+      # generated URL:
+      # http://transparencydata.com/api/1.0/aggregates/pol/4148b26f6f1c437cb50ea9ca4699417a/contributors/industries.json?apikey=<key>&cycle=2012
+      def self.top_industry_contributors(id, ops = {})
+        response = get("/aggregates/pol/#{id}/contributors/industries.json", :query => ops)
+        parse(response)
+      end
     end
 
     class Categories

--- a/spec/fixtures/transparency_data/top_industry.response
+++ b/spec/fixtures/transparency_data/top_industry.response
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+Server: nginx/1.0.5
+Date: Wed, 27 Mar 2013 16:28:15 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+
+[{"count": "88315", "amount": "43633891.00", "id": "b21467ae32924f84ada9076535401a91", "should_show_entity": false, "name": "RETIRED"},{"count": "29116", "amount": "22547853.00", "id": "f50cf984a2e3477c8167d32e2b14e052", "should_show_entity": true, "name": "LAWYERS/LAW FIRMS"},{"count": "35121", "amount": "16971085.00", "id": "31657d3c187e4cecb670d228d7e674d2", "should_show_entity": true, "name": "EDUCATION"},{"count": "15592", "amount": "8396517.00", "id": "a05a0d06f6814b31bece35a81fcb40c7", "should_show_entity": true, "name": "HEALTH PROFESSIONALS"},{"count": "10542", "amount": "7027745.00", "id": "e5175721aac9406795a1f97cae01e01d", "should_show_entity": true, "name": "BUSINESS SERVICES"},{"count": "13597", "amount": "6513032.00", "id": "9e701425eeb14b4c874cfb4415a4ac3b", "should_show_entity": true, "name": "CIVIL SERVANTS/PUBLIC OFFICIALS"},{"count": "9662", "amount": "6374741.00", "id": "042288e0185a44ec82982814c69abdca", "should_show_entity": true, "name": "COMPUTERS/INTERNET"},{"count": "9474", "amount": "6344932.00", "id": "6e1074968db94bf4851c0245cd8583bf", "should_show_entity": true, "name": "WOMEN'S ISSUES"},{"count": "4760", "amount": "5459825.00", "id": "0af3f418f426497e8bbf916bfc074ebc", "should_show_entity": true, "name": "SECURITIES & INVESTMENT"},{"count": "9319", "amount": "5394743.00", "id": "d9c4a26cd671436eac3c501184364fc4", "should_show_entity": false, "name": "MISC BUSINESS"}]

--- a/spec/transparency_data_spec.rb
+++ b/spec/transparency_data_spec.rb
@@ -141,7 +141,7 @@ module GovKit::TransparencyData
 
       it 'should return a 404 error for an invalid politician ID' do
         lambda do
-          @sector_contributors = Aggregate.top_sector_contributors('a_bogus_politician_id')
+          @sector_contributors = Aggregate.top_industry_contributors('a_bogus_politician_id')
         end.should raise_error
       end
     end

--- a/spec/transparency_data_spec.rb
+++ b/spec/transparency_data_spec.rb
@@ -17,7 +17,8 @@ module GovKit::TransparencyData
           ['/aggregates/pol/4148b26f6f1c437cb50ea9ca4699417a/contributors/sectors.json\?apikey=&cycle=2012',  'aggregates_contributors_sectors.response'],
           ['/aggregates/pol/a_bogus_politician_id/contributors/sectors.json\?apikey=',  '404.response'],
           ['/aggregates/pol/4148b26f6f1c437cb50ea9ca4699417a/contributors/type_breakdown.json\?apikey=&cycle=2012',  'aggregates_contributor_type_breakdown.response'],
-          ['/aggregates/pol/a_bogus_politician_id/contributors/type_breakdown.json\?apikey=',  '404.response']
+          ['/aggregates/pol/a_bogus_politician_id/contributors/type_breakdown.json\?apikey=',  '404.response'],
+          ['/aggregates/pol/4148b26f6f1c437cb50ea9ca4699417a/contributors/industries.json\?apikey=&cycle=2012', 'top_industry.response']
         ]
 
         urls.each do |u|
@@ -127,6 +128,23 @@ module GovKit::TransparencyData
       end
     end
 
+    context "#top_industry_contributors" do
+      it "should find the top industry contributors for Obama in 2012" do
+        lambda do
+          @industry_contributors = Aggregate.top_industry_contributors('4148b26f6f1c437cb50ea9ca4699417a', { :cycle => '2012' })
+        end.should_not raise_error
+
+        @industry_contributors.length.should eql(10)
+        @industry_contributors[0].name.should eql("RETIRED")
+        @industry_contributors[9].count.should eql("9319")
+      end
+
+      it 'should return a 404 error for an invalid politician ID' do
+        lambda do
+          @sector_contributors = Aggregate.top_sector_contributors('a_bogus_politician_id')
+        end.should raise_error
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Added GovKit::TransparencyData::Aggregate#top_industry_contributors. 

It's not in the documentation (which I'm told is being overhauled), but the endpoint exists and 
is used by the [python wrapper](https://github.com/sunlightlabs/python-transparencydata/blob/master/influenceexplorer.py#L287). 

I also added response fixture and some tests.
