### PR TITLE
Drop iconv

### DIFF
--- a/lib/gov_kit.rb
+++ b/lib/gov_kit.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.i
 
 require 'csv'
 require 'digest/md5'
-require 'iconv'
 require 'json'
 require 'open-uri'
 


### PR DESCRIPTION
iconv wasn't being used. Requiring it throws deprecation warnings.
